### PR TITLE
ChatGPT generated versions

### DIFF
--- a/dontstopbelieving-gpt.wtf
+++ b/dontstopbelieving-gpt.wtf
@@ -1,0 +1,78 @@
+# A small town girl living in a lonely world
+// JavaScript
+const girl = new Person('small town');
+const world = new World('lonely');
+girl.moveToWorld(world);
+
+// She took the midnight train going anywhere
+// Python
+train = Train('midnight')
+girl.board(train)
+
+// Just a city boy, born and raised in South Detroit
+-- Lua
+boy = Person('city')
+boy.birthplace = 'South Detroit'
+
+// He took the midnight train going anywhere
+// Swift
+boy.board(train)
+
+// A singer in a smoky room, a smell of wine and cheap perfume
+// Ruby
+singer = Person.new('singer')
+room = Room.new('smoky')
+room.smell('wine', 'cheap perfume')
+singer.enter(room)
+
+// For a smile they can share the night
+// PHP
+singer.smile(girl)
+singer.smile(boy)
+girl.shareNight()
+boy.shareNight()
+
+// It goes on and on and on and on
+// C
+while (true) {
+  continuePlayingSong();
+}
+
+// Strangers waiting, up and down the boulevard
+// Go
+boulevard := Street('boulevard')
+strangers := make([]Person, 10)
+for i := range strangers {
+  stranger := Person{}
+  boulevard.wait(stranger)
+  strangers[i] = stranger
+}
+
+// Their shadows searching in the night
+// Rust
+let night = Time::new('night');
+for stranger in strangers.iter() {
+  stranger.search(night);
+}
+
+// Streetlights people, living just to find emotion
+// Java
+ArrayList<Person> people = new ArrayList<Person>();
+for (int i = 0; i < 10; i++) {
+  Person person = new Person();
+  person.job = "streetlight maintenance worker";
+  person.mission = "help people find emotion";
+  people.add(person);
+}
+
+// Hiding somewhere in the night
+// Kotlin
+for (person in people) {
+  person.hide(night);
+}
+
+// Don't stop believin', hold on to that feeling
+// Assembly
+while (true) {
+  holdOnToFeeling();
+}

--- a/ruby/dontstopbelieving-gpt.rb
+++ b/ruby/dontstopbelieving-gpt.rb
@@ -1,0 +1,66 @@
+# A small town girl living in a lonely world
+girl = Person.new("small town")
+world = World.new("lonely")
+girl.move_to(world)
+
+# She took the midnight train going anywhere
+train = Train.new("midnight")
+girl.board(train)
+
+# Just a city boy, born and raised in South Detroit
+boy = Person.new("city")
+boy.birthplace = "South Detroit"
+
+# He took the midnight train going anywhere
+boy.board(train)
+
+# A singer in a smoky room, a smell of wine and cheap perfume
+singer = Person.new("singer")
+room = Room.new("smoky")
+room.smell("wine", "cheap perfume")
+singer.enter(room)
+
+# For a smile they can share the night
+singer.smile(girl)
+singer.smile(boy)
+girl.share_night
+boy.share_night
+
+# It goes on and on and on and on
+while true do
+  continue_playing_song
+end
+
+# Strangers waiting, up and down the boulevard
+boulevard = Street.new("boulevard")
+strangers = []
+10.times do
+  stranger = Person.new
+  boulevard.wait(stranger)
+  strangers << stranger
+end
+
+# Their shadows searching in the night
+night = Time.new("night")
+strangers.each do |stranger|
+  stranger.search(night)
+end
+
+# Streetlights people, living just to find emotion
+people = []
+10.times do
+  person = Person.new
+  person.job = "streetlight maintenance worker"
+  person.mission = "help people find emotion"
+  people << person
+end
+
+# Hiding somewhere in the night
+people.each do |person|
+  person.hide(night)
+end
+
+# Don't stop believin', hold on to that feeling
+while true do
+  hold_on_to_feeling
+end


### PR DESCRIPTION
They need some work but they were actually good enough I think to provide some ideas at least to steal so adding them anyway.

If you want to play more with it the prompt I used was:

```
Express Journey's "Don't Stop Believin" as Ruby code. Minimize putting the
lyrics in strings but instead make it so you "hear" the song as you read the
code itself. It does not need to to output the lyrics. The code itself follows
the lyrics.
```

With the polyglot theme of the conference I then did a follow-up to see if it could modify that to be a bunch of languages (I think the final intention of the shirt). Gave it the follow-up prompt:

```
Update this so each lyric is in a different programming language and note the
language in a comment.
```

This results in the `dontstopbelieving-gpt.wtf` file. This one needs even more work as the last example is obviously not assembly, PHP should have semi-colon's, the comment syntax is a bit wonky but still not bad.

If I get time later I may to a follow-up PR that cleans up the attempts with my own adjustments. Sort of an eric/gpt collaboration. But going ahead and sending up the raw GPT versions for now in case time is never made.