### PR TITLE
feat(bohemian.rhapsody):  added bash support

### DIFF
--- a/bash/bohemian.rhapsody.chruck.bash
+++ b/bash/bohemian.rhapsody.chruck.bash
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Submitted by Jas Eckard
+
+# [Verse 1]
+# Mama, just killed a man
+pkill -SIGKILL --parent $(pidof Mama) man    # bash

--- a/lilypond/Makefile
+++ b/lilypond/Makefile
@@ -1,0 +1,5 @@
+all:
+	docker run --rm -v $(PWD):/work codello/lilypond bohemianrhapsody.chruck.ly
+
+clean:
+	rm bohemianrhapsody.chruck.pdf bohemianrhapsody.chruck.midi

--- a/lilypond/bohemianrhapsody.chruck.ly
+++ b/lilypond/bohemianrhapsody.chruck.ly
@@ -1,0 +1,20 @@
+% Bohemian Rhapsody, Guitar Solo
+% between Verse 2 and Verse 3, starting after:
+%       sometimes wish I'd never been born at all
+% and leading into
+%       I see a little silhouetto of a man
+
+\language "english"  % default naming convention is Dutch note names
+\score {
+  \relative c''' {  % most notes are above the treble clef
+    \key ef \major
+
+    r4 g8 f16 ef bf'4. g8 c2 c8 d16 ef c8 d16 ef f2 f16 g af bf c4
+    \tuplet 6/4 4 { bf16 af g af g f g f ef f ef d ef d c d c bf( } bf4)
+    r16 bf c d ef32 f g af bf8 r16 bf, c d ef32 f g af bf8
+    c4. d,16 ef c8 d16 ef c8 d16 ef f4. f,16 g af4 f'
+    \tuplet 3/2 {af,2 df8 df} df4 df, a8 r r4 r2
+  }
+  \layout {}  % outputs sheet music
+  \midi {}    % outputs a MIDI file
+}

--- a/lilypond/bohemianrhapsody.chruck.min.ly
+++ b/lilypond/bohemianrhapsody.chruck.min.ly
@@ -1,0 +1,27 @@
+% Bohemian Rhapsody, Guitar Solo
+% by Jas Eckard (chruck)
+
+% between Verse 2 and Verse 3, starting after:
+%       sometimes wish I'd never been born at all
+% and leading into
+%       I see a little silhouetto of a man
+
+% This file is the minimal/compact version, just the notes so that
+% they fit on a T-shirt:  This will not compile (use `make` with
+% `docker` to compile `bohemianrhapsodychruck.ly`). but is within 80
+% columns:
+
+r4 g8 f16 ef bf'4. g8 c2 c8 d16 ef c8 d16 ef f2 f16 g af bf c4  % LilyPond:
+\tuplet 6/4 4 { bf16 af g af g f g f ef f ef d ef d c d c bf(   % electric
+} bf4) r16 bf c d ef32 f g af bf8 r16 bf, c d ef32 f g af bf8   % guitar
+c4. d,16 ef c8 d16 ef c8 d16 ef f4. f,16 g af4 f' \tuplet 3/2 { % solo
+af,2 df8 df} df4 df, a8 r r4 r2
+
+% 60 columns (reminder that Ansible section was 6 lines last year!):
+
+r4 g8 f16 ef bf'4. g8 c2 c8 d16 ef c8 d16 ef f2  % LilyPond:
+f16 g af bf c4 \tuplet 6/4 4 { bf16 af g af g f  % electric
+g f ef f ef d ef d c d c bf( } bf4) r16 bf c d   % guitar
+ef32 f g af bf8 r16 bf, c d ef32 f g af bf8 c4.  % solo
+d,16 ef c8 d16 ef c8 d16 ef f4. f,16 g af4 f'
+\tuplet 3/2 { af,2 df8 df} df4 df, a8 r r4 r2


### PR DESCRIPTION
Found the best line so far that is indicative of BASH, the first phrase of the first verse:

```
[Verse 1]
Mama, just killed a man
```

Reasons:

- `kill` is a program used to send signals to running processes, `pkill` matches patterns instead of requiring a PID
- `SIGKILL` is the name of a signal, would have been nice if there were a signal called "just" or "gun" (for the next phrase)
- `Mama` is a natural name for a parent process
- `man` is a Unix command