### PR TITLE
Lilypond Guitar Solo

### DIFF
--- a/lilypond/.gitignore
+++ b/lilypond/.gitignore
@@ -1,0 +1,2 @@
+bohemianrhapsody.chruck.midi
+bohemianrhapsody.chruck.pdf

--- a/lilypond/Makefile
+++ b/lilypond/Makefile
@@ -1,0 +1,5 @@
+all:
+	docker run --rm -v $(PWD):/work codello/lilypond bohemianrhapsody.chruck.ly
+
+clean:
+	rm bohemianrhapsody.chruck.pdf bohemianrhapsody.chruck.midi

--- a/lilypond/bohemianrhapsody.chruck.ly
+++ b/lilypond/bohemianrhapsody.chruck.ly
@@ -6,9 +6,10 @@
 % and leading into
 %       I see a little silhouetto of a man
 
+\version "2.24.3"    % remove 'version' warning
 \language "english"  % default naming convention is Dutch note names
 \score {
-  \relative c''' {  % most notes are above the treble clef
+  \relative c''' {   % most notes are above the treble clef
     \key ef \major
 
     r4 g8 f16 ef bf'4. g8 c2 c8 d16 ef c8 d16 ef f2 f16 g af bf c4

--- a/lilypond/bohemianrhapsody.chruck.ly
+++ b/lilypond/bohemianrhapsody.chruck.ly
@@ -1,0 +1,22 @@
+% Bohemian Rhapsody, Guitar Solo
+% by Jas Eckard (chruck)
+
+% between Verse 2 and Verse 3, starting after:
+%       sometimes wish I'd never been born at all
+% and leading into
+%       I see a little silhouetto of a man
+
+\language "english"  % default naming convention is Dutch note names
+\score {
+  \relative c''' {  % most notes are above the treble clef
+    \key ef \major
+
+    r4 g8 f16 ef bf'4. g8 c2 c8 d16 ef c8 d16 ef f2 f16 g af bf c4
+    \tuplet 6/4 4 { bf16 af g af g f g f ef f ef d ef d c d c bf( } bf4)
+    r16 bf c d ef32 f g af bf8 r16 bf, c d ef32 f g af bf8
+    c4. d,16 ef c8 d16 ef c8 d16 ef f4. f,16 g af4 f'
+    \tuplet 3/2 {af,2 df8 df} df4 df, a8 r r4 r2
+  }
+  \layout {}  % outputs sheet music
+  \midi {}    % outputs a MIDI file
+}

--- a/lilypond/bohemianrhapsody.chruck.min.ly
+++ b/lilypond/bohemianrhapsody.chruck.min.ly
@@ -1,0 +1,27 @@
+% Bohemian Rhapsody, Guitar Solo
+% by Jas Eckard (chruck)
+
+% between Verse 2 and Verse 3, starting after:
+%       sometimes wish I'd never been born at all
+% and leading into
+%       I see a little silhouetto of a man
+
+% This file is the minimal/compact version, just the notes so that
+% they fit on a T-shirt:  This will not compile (use `make` with
+% `docker` to compile `bohemianrhapsody.chruck.ly`). but is within 80
+% columns:
+
+r4 g8 f16 ef bf'4. g8 c2 c8 d16 ef c8 d16 ef f2 f16 g af bf c4  % LilyPond:
+\tuplet 6/4 4 { bf16 af g af g f g f ef f ef d ef d c d c bf(   % electric
+} bf4) r16 bf c d ef32 f g af bf8 r16 bf, c d ef32 f g af bf8   % guitar
+c4. d,16 ef c8 d16 ef c8 d16 ef f4. f,16 g af4 f' \tuplet 3/2 { % solo
+af,2 df8 df} df4 df, a8 r r4 r2
+
+% 60 columns (reminder that Ansible section was 6 lines last year!):
+
+r4 g8 f16 ef bf'4. g8 c2 c8 d16 ef c8 d16 ef f2  % LilyPond:
+f16 g af bf c4 \tuplet 6/4 4 { bf16 af g af g f  % electric
+g f ef f ef d ef d c d c bf( } bf4) r16 bf c d   % guitar
+ef32 f g af bf8 r16 bf, c d ef32 f g af bf8 c4.  % solo
+d,16 ef c8 d16 ef c8 d16 ef f4. f,16 g af4 f'
+\tuplet 3/2 { af,2 df8 df} df4 df, a8 r r4 r2


### PR DESCRIPTION
I decided to add the guitar solo between the second and third verse, written in LilyPond.

- `lilypond/bohemianrhapsody.chruck.ly`
  - An actual valid LilyPond file, that creates:
    - a PDF of the sheet music
    - a MIDI file to hear it
- `lilypond/bohemianrhapsody.chruck.min.ly`
  - The guts of the above LilyPond file, the actual notes.
  - 2 different sections of the notes, to be chosen between for space on the T-Shirt:
    - 80-column version
    - 60-column version
- `Makefile`
  - Uses `make` to compile the `.ly` file into the `.pdf` and `.midi` files, via `docker`
  - `clean` target to delete the `.pdf` and `.midi` files

(Originally in PR #14)