### PR TITLE
Add Cloud Agent development environment

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "name": "Carolina Code Conf Lyrical Challenge",
+  "install": "./.cursor/install.sh"
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Idempotent polyglot toolchain bootstrap for the Carolina Code Conf Lyrical
+# Challenge. The Cloud Agent default image already ships Python, Node.js, Java,
+# Go, Rust, GCC/G++, Perl and Bash. This script adds the remaining commonly
+# used interpreters/compilers for the challenge's most represented languages so
+# contributors can write and syntax-check their lyric entries.
+set -euo pipefail
+
+PACKAGES=(
+  ruby        # ruby/*.rb entries
+  php-cli     # php/*.php entries
+  lua5.4      # lua/*.lua entries
+  sqlite3     # sql/*.sql entries
+)
+
+# Only touch apt when something is actually missing so reruns are cheap.
+missing=()
+command -v ruby     >/dev/null 2>&1 || missing+=(ruby)
+command -v php      >/dev/null 2>&1 || missing+=(php-cli)
+command -v lua5.4   >/dev/null 2>&1 || missing+=(lua5.4)
+command -v sqlite3  >/dev/null 2>&1 || missing+=(sqlite3)
+
+if [ "${#missing[@]}" -gt 0 ]; then
+  echo "Installing missing toolchains: ${missing[*]}"
+  sudo apt-get update -qq
+  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends "${missing[@]}"
+else
+  echo "All extra toolchains already present; nothing to install."
+fi
+
+echo "=== Installed language toolchains ==="
+for probe in \
+  "ruby --version" \
+  "php --version" \
+  "python3 --version" \
+  "node --version" \
+  "java -version" \
+  "go version" \
+  "rustc --version" \
+  "gcc --version" \
+  "perl --version" \
+  "bash --version" \
+  "lua5.4 -v" \
+  "sqlite3 --version"; do
+  printf '%-8s -> ' "${probe%% *}"
+  $probe 2>&1 | head -1 || echo "unavailable"
+done


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a Cloud Agent development environment for this polyglot lyrical-code challenge repo. The repo has no build/test system — it's a collection of song-lyric snippets across ~60 languages destined for a conference t-shirt (the README notes "it's more important that the code reads than actually compiles"). The real developer experience is therefore a **working polyglot toolchain** so contributors can write and syntax-check their entries.

## What was added

- `.cursor/environment.json` — names the environment and points `install` at the bootstrap script.
- `.cursor/install.sh` — idempotent script that adds the commonly-used toolchains missing from the default image and prints installed versions.

The Cloud Agent default image already ships Python, Node.js, Java, Go, Rust, GCC/G++, Perl and Bash. The install script adds the remaining well-represented, easily-installed toolchains via `apt`:

| Package | Covers |
| --- | --- |
| `ruby` | `ruby/*.rb` |
| `php-cli` | `php/*.php` |
| `lua5.4` | `lua/*.lua` |
| `sqlite3` | `sql/*.sql` |

Together these cover the most-represented languages in the repo (JS, Java, Ruby, Python, PHP, SQL, C/C++, Perl, Go, Rust, Bash, Lua). More exotic toolchains (e.g. Elixir, Erlang, Haskell, .NET/C#, Swift, Dart, COBOL, Fortran) are intentionally left out to keep the image lean; they can be added on request.

`install` is idempotent: it only invokes `apt` when a toolchain is actually missing, so reruns and snapshot boots are cheap.

## Validation

| Check | Result |
| --- | --- |
| Install runs & terminates | Passed (exit 0), versions printed |
| Install idempotence | Passed twice ("already present; nothing to install") |
| Draft environment build | SUCCEEDED — `install.sh` ran and printed all 12 toolchain versions |
| Fresh Cloud Agent (booted from the tested build) | Passed — 12/12 toolchains present, 8 interpreters + 4 compilers executed real programs |

All 13 language runtimes execute a real program end-to-end (each printing a lyric line), and the toolchains parse the repo's cleanly-authored entries (e.g. Python 3/5, Node 4/5, Perl 1/1, Bash 2/2 parse — the rest are intentional lyric art).

[Verification log](https://cursor.com/agents/bc-397d49a9-f0e7-4a44-a5e2-d387a1b4b98c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fenvironment_verification.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-397d49a9-f0e7-4a44-a5e2-d387a1b4b98c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-397d49a9-f0e7-4a44-a5e2-d387a1b4b98c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

